### PR TITLE
Change publisher to ABB in dummy app

### DIFF
--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -7,7 +7,7 @@ export default class ApplicationController extends Controller {
       name: 'insert-variable',
       options: {
         publisher:
-          'http://data.lblod.info/id/bestuurseenheden/cec59e5e872a9084e93becf3026bfcc2f25926ea76372711b7a745875f3b7949',
+          'http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b',
       },
     },
   ];


### PR DESCRIPTION
When testing with the MOW or regulatory statements registry, this plugin should fetch codelists created by ABB.